### PR TITLE
ensuring session is not null in clearLineMarks

### DIFF
--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -4623,6 +4623,7 @@ Session::clearLineMarks = ->
   @view.clearMarks()
 
 Editor::clearLineMarks = ->
+  return unless @session?
   @session.clearLineMarks()
 
   @redrawMain()


### PR DESCRIPTION
@crossroads1112 you build with just `grunt build`, right?